### PR TITLE
Update url to the next wiki page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   <description>
     This plugin makes CloudBees DevOptics components available in Jenkins.
   </description>
-  <url>https://wiki.jenkins.io/display/JENKINS/CloudBees+DevOptics+Enabler+Plugin</url>
+  <url>https://wiki.jenkins.io/display/JENKINS/CloudBees+DevOptics+Installation+Plugin</url>
   <licenses>
     <license>
       <name>The MIT license</name>


### PR DESCRIPTION
I noticed the plugin in the update center goes to the wrong url.

Quick update to goto https://wiki.jenkins.io/display/JENKINS/CloudBees+DevOptics+Installation+Plugin now that its been renamed in the wiki.